### PR TITLE
🧪 Add tests for haptic event emissions

### DIFF
--- a/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
+++ b/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
@@ -206,19 +206,16 @@ class TimerViewModelTest {
         viewModel.sync4Min() // Emits MARK_60S at 4m
         runCurrent()
 
-        assertEquals(listOf(HapticType.MARK_60S), events)
+        val expectedEvents = mutableListOf(HapticType.MARK_60S)
+        assertEquals(expectedEvents, events)
 
-        // Advance 1 minute
-        advanceTimeBy(60000)
-        runCurrent()
-
-        assertEquals(listOf(HapticType.MARK_60S, HapticType.MARK_60S), events)
-
-        // Advance another minute
-        advanceTimeBy(60000)
-        runCurrent()
-
-        assertEquals(listOf(HapticType.MARK_60S, HapticType.MARK_60S, HapticType.MARK_60S), events)
+        // Advance minute by minute and check for new events
+        repeat(2) {
+            advanceTimeBy(60000)
+            runCurrent()
+            expectedEvents.add(HapticType.MARK_60S)
+            assertEquals(expectedEvents, events)
+        }
 
         viewModel.reset()
     }

--- a/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
+++ b/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
@@ -262,7 +262,8 @@ class TimerViewModelTest {
         advanceTimeBy(60000)
         runCurrent()
 
-        // The last event should be START
+        // The last event should be START, and there should be 11 events total (10 ticks + 1 start).
+        assertEquals(11, events.size)
         assertEquals(HapticType.START, events.last())
 
         viewModel.reset()

--- a/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
+++ b/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
@@ -2,6 +2,7 @@ package com.example.bumpscountdowntimer.ui.timer
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.*
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -189,6 +190,94 @@ class TimerViewModelTest {
         assertEquals(TimerState.ROLLING_HOLD, viewModel.timerState.value)
         assertEquals(true, viewModel.isHoldingFor4Min.value)
         
+        viewModel.reset()
+    }
+
+    @Test
+    fun `hapticEvents emits 60s mark at minute boundaries`() = runTest(timeout = 10.seconds) {
+        val viewModel = createViewModel()
+        val events = mutableListOf<HapticType>()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.hapticEvents.collect { events.add(it) }
+        }
+
+        // Start a 4 minute sequence
+        viewModel.sync4Min() // Emits MARK_60S at 4m
+        runCurrent()
+
+        assertEquals(listOf(HapticType.MARK_60S), events)
+
+        // Advance 1 minute
+        advanceTimeBy(60000)
+        runCurrent()
+
+        assertEquals(listOf(HapticType.MARK_60S, HapticType.MARK_60S), events)
+
+        // Advance another minute
+        advanceTimeBy(60000)
+        runCurrent()
+
+        assertEquals(listOf(HapticType.MARK_60S, HapticType.MARK_60S, HapticType.MARK_60S), events)
+
+        viewModel.reset()
+    }
+
+    @Test
+    fun `hapticEvents emits tick 1s during final 10 seconds`() = runTest(timeout = 10.seconds) {
+        val viewModel = createViewModel()
+        val events = mutableListOf<HapticType>()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.hapticEvents.collect { events.add(it) }
+        }
+
+        // Start 1 minute sequence
+        viewModel.sync1Min()
+        runCurrent()
+        events.clear() // Clear initial MARK_60S
+
+        // Advance to 10 seconds remaining
+        advanceTimeBy(50000)
+        runCurrent()
+
+        // At exactly 10s remaining, it should emit TICK_1S
+        assertEquals(listOf(HapticType.TICK_1S), events)
+
+        // Advance 1 second
+        advanceTimeBy(1000)
+        runCurrent()
+        assertEquals(listOf(HapticType.TICK_1S, HapticType.TICK_1S), events)
+
+        // Advance 8 more seconds to 1 second remaining
+        advanceTimeBy(8000)
+        runCurrent()
+        assertEquals(10, events.size)
+        assertEquals(HapticType.TICK_1S, events.last())
+
+        viewModel.reset()
+    }
+
+    @Test
+    fun `hapticEvents emits START at zero`() = runTest(timeout = 10.seconds) {
+        val viewModel = createViewModel()
+        val events = mutableListOf<HapticType>()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.hapticEvents.collect { events.add(it) }
+        }
+
+        viewModel.sync1Min()
+        runCurrent()
+        events.clear() // Clear initial MARK_60S
+
+        // Advance past zero
+        advanceTimeBy(60000)
+        runCurrent()
+
+        // The last event should be START
+        assertEquals(HapticType.START, events.last())
+
         viewModel.reset()
     }
 

--- a/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
+++ b/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
@@ -234,23 +234,13 @@ class TimerViewModelTest {
         runCurrent()
         events.clear() // Clear initial MARK_60S
 
-        // Advance to 10 seconds remaining
-        advanceTimeBy(50000)
+        // Advance to 1 second remaining, which should trigger all 10 ticks.
+        advanceTimeBy(59000)
         runCurrent()
 
-        // At exactly 10s remaining, it should emit TICK_1S
-        assertEquals(listOf(HapticType.TICK_1S), events)
-
-        // Advance 1 second
-        advanceTimeBy(1000)
-        runCurrent()
-        assertEquals(listOf(HapticType.TICK_1S, HapticType.TICK_1S), events)
-
-        // Advance 8 more seconds to 1 second remaining
-        advanceTimeBy(8000)
-        runCurrent()
-        assertEquals(10, events.size)
-        assertEquals(HapticType.TICK_1S, events.last())
+        // Verify that 10 TICK_1S events were emitted.
+        val expectedEvents = List(10) { HapticType.TICK_1S }
+        assertEquals(expectedEvents, events)
 
         viewModel.reset()
     }


### PR DESCRIPTION
🎯 **What:** Added missing tests for haptic event emissions from the `TimerViewModel`.
📊 **Coverage:** The new tests cover:
- Emitting the `MARK_60S` event at minute boundaries (e.g., at 4m, 3m, 2m, 1m).
- Emitting the `TICK_1S` event every second during the final 10 seconds of the countdown.
- Emitting the `START` event when the timer reaches zero.
✨ **Result:** Improved test coverage and reliability for haptic feedback functionality, ensuring correct behavior without causing flakiness.

---
*PR created automatically by Jules for task [1743834047554378279](https://jules.google.com/task/1743834047554378279) started by @triskaidekafeliks*