### PR TITLE
Remove obsolete 'Fix' comment for TimePicker MaterialTheme

### DIFF
--- a/app/src/main/java/com/example/bumpscountdowntimer/ui/timer/TimerScreen.kt
+++ b/app/src/main/java/com/example/bumpscountdowntimer/ui/timer/TimerScreen.kt
@@ -304,6 +304,8 @@ fun ScheduledTimePickerDialog(
                 .width(IntrinsicSize.Min)
                 .height(IntrinsicSize.Min)
         ) {
+            // Wrap TimePicker in a local MaterialTheme with standard typography
+            // to prevent it from inheriting the massive 120sp global displayLarge.
             MaterialTheme(
                 typography = MaterialTheme.typography.copy(
                     displayLarge = TextStyle(

--- a/app/src/main/java/com/example/bumpscountdowntimer/ui/timer/TimerScreen.kt
+++ b/app/src/main/java/com/example/bumpscountdowntimer/ui/timer/TimerScreen.kt
@@ -304,8 +304,6 @@ fun ScheduledTimePickerDialog(
                 .width(IntrinsicSize.Min)
                 .height(IntrinsicSize.Min)
         ) {
-            // Fix: Wrap TimePicker in a local MaterialTheme with standard typography
-            // to prevent it from inheriting the massive 120sp global displayLarge.
             MaterialTheme(
                 typography = MaterialTheme.typography.copy(
                     displayLarge = TextStyle(


### PR DESCRIPTION
Removed the obsolete comment directing to wrap TimePicker in a MaterialTheme, as the code directly below the comment already implements this functionality.

---
*PR created automatically by Jules for task [13834270760107776581](https://jules.google.com/task/13834270760107776581) started by @triskaidekafeliks*