### PR TITLE
🧹 Simplify conditionals in startRollingHold

### DIFF
--- a/app/src/main/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModel.kt
+++ b/app/src/main/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModel.kt
@@ -85,16 +85,19 @@ class TimerViewModel(
         // If we start hold while waiting for the sequence to begin or at the very start, it's for the 4-min gun.
         updateHoldState(currentState)
         
-        if (currentState == TimerState.IDLE) {
-            startSequence(ONE_MINUTE_MILLIS, TimerState.ROLLING_HOLD)
+        val duration = calculateHoldDuration(currentState, now)
+        startSequence(duration, TimerState.ROLLING_HOLD, now)
+    }
+
+    private fun calculateHoldDuration(currentState: TimerState, now: Long): Long {
+        return if (currentState == TimerState.IDLE) {
+            ONE_MINUTE_MILLIS
         } else {
             // Preserve the "phase" of the seconds relative to the current target
             val newTarget = calculateNextTargetTime(now)
             // If newTarget is in the future, we keep it. This ensures that if we press 
             // "Rolling Hold" 5s before a gun, the prompt still appears at the original time.
-            
-            val duration = newTarget - now
-            startSequence(duration, TimerState.ROLLING_HOLD, now)
+            newTarget - now
         }
     }
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Extracted duration calculation in `startRollingHold` into a new helper function `calculateHoldDuration` to simplify conditionals.

💡 **Why:** How this improves maintainability
The change removes the duplicated `startSequence` call and flattens the execution flow of `startRollingHold`. This makes the code much easier to follow and logically separates the intent of duration calculation from sequence initiation.

✅ **Verification:** How you confirmed the change is safe
Ran the `TimerViewModelTest` unit test suite which passed successfully (`./gradlew :app:testDebugUnitTest --tests "*TimerViewModelTest*"`). Evaluated that the change does not alter behavior since the `now` parameter was safely defaulted in the original implementation. Code review confirmed the safety and correctness of the change.

✨ **Result:** The improvement achieved
A single line execution path to `startSequence` with clear logical abstraction for calculating the duration, keeping the refactor safely under 20 lines.

---
*PR created automatically by Jules for task [17197046631921476169](https://jules.google.com/task/17197046631921476169) started by @triskaidekafeliks*