### PR TITLE
🧪 Add missing tests for haptic event emissions

### DIFF
--- a/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
+++ b/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
@@ -270,6 +270,80 @@ class TimerViewModelTest {
     }
 
     @Test
+    fun `hapticEvents emits MARK_60S when PRE_SEQUENCE expires and transitions to ROLLING_HOLD`() = runTest(timeout = 10.seconds) {
+        val viewModel = createViewModel()
+        val events = mutableListOf<HapticType>()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.hapticEvents.collect { events.add(it) }
+        }
+
+        val startTime = currentTime + 10.minutes.inWholeMilliseconds
+        viewModel.setScheduledStartTime(startTime)
+
+        // Wait until 4-min gun time
+        advanceTimeBy(6.minutes.inWholeMilliseconds)
+        runCurrent()
+
+        // Assert that MARK_60S was emitted during the transition to ROLLING_HOLD
+        assertEquals(TimerState.ROLLING_HOLD, viewModel.timerState.value)
+        assertEquals(true, events.contains(HapticType.MARK_60S))
+
+        viewModel.reset()
+    }
+
+    @Test
+    fun `hapticEvents trackers are reset when a new sequence starts`() = runTest(timeout = 10.seconds) {
+        val viewModel = createViewModel()
+        val events = mutableListOf<HapticType>()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.hapticEvents.collect { events.add(it) }
+        }
+
+        // Start 1 minute sequence and let it tick down to final 10 seconds
+        viewModel.sync1Min()
+        advanceTimeBy(59000)
+        runCurrent()
+
+        // Ensure TICK_1S events are in the list
+        val hasTick1S = events.contains(HapticType.TICK_1S)
+        assertEquals(true, hasTick1S)
+        events.clear()
+
+        // Restart 1 minute sequence to see if trackers were reset and TICK_1S can happen again
+        viewModel.sync1Min()
+        advanceTimeBy(59000)
+        runCurrent()
+
+        val hasTick1SAgain = events.contains(HapticType.TICK_1S)
+        assertEquals(true, hasTick1SAgain)
+
+        viewModel.reset()
+    }
+
+    @Test
+    fun `no haptic events emitted in IDLE state`() = runTest(timeout = 10.seconds) {
+        val viewModel = createViewModel()
+        val events = mutableListOf<HapticType>()
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            viewModel.hapticEvents.collect { events.add(it) }
+        }
+
+        // Initially in IDLE state
+        assertEquals(TimerState.IDLE, viewModel.timerState.value)
+
+        // Wait for some time to ensure no pulses happen in IDLE
+        advanceTimeBy(120000)
+        runCurrent()
+
+        assertEquals(true, events.isEmpty())
+
+        viewModel.reset()
+    }
+
+    @Test
     fun `reset resets all state flows to default values`() = runTest(timeout = 10.seconds) {
         val viewModel = createViewModel()
 

--- a/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
+++ b/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
@@ -307,8 +307,8 @@ class TimerViewModelTest {
         runCurrent()
 
         // Ensure TICK_1S events are in the list
-        val hasTick1S = events.contains(HapticType.TICK_1S)
-        assertEquals(true, hasTick1S)
+        val expectedTicks = List(10) { HapticType.TICK_1S }
+        assertEquals(expectedTicks, events.filter { it == HapticType.TICK_1S })
         events.clear()
 
         // Restart 1 minute sequence to see if trackers were reset and TICK_1S can happen again

--- a/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
+++ b/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
@@ -316,8 +316,8 @@ class TimerViewModelTest {
         advanceTimeBy(59000)
         runCurrent()
 
-        val hasTick1SAgain = events.contains(HapticType.TICK_1S)
-        assertEquals(true, hasTick1SAgain)
+        val expectedTicks = List(10) { HapticType.TICK_1S }
+        assertEquals(expectedTicks, events.filter { it == HapticType.TICK_1S })
 
         viewModel.reset()
     }


### PR DESCRIPTION
🎯 **What:** Added tests for the previously untested haptic event flows in `TimerViewModel`.
📊 **Coverage:** The new tests cover:
- Emitting `MARK_60S` during the transition from `PRE_SEQUENCE` to `ROLLING_HOLD`.
- Verify `resetHapticTrackers()` functions correctly and allows events to re-fire upon sequence restart.
- Ensuring no stray events occur in the `IDLE` state.
✨ **Result:** Improved test coverage around `hapticEvents` and haptic tracker variables (`lastHapticMinute`, `lastHapticSecond`).

---
*PR created automatically by Jules for task [14352459398023944428](https://jules.google.com/task/14352459398023944428) started by @triskaidekafeliks*