### PR TITLE
🧪 [testing improvement] Add test for 1-minute hold confirmation

### DIFF
--- a/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
+++ b/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
@@ -36,6 +36,38 @@ class TimerViewModelTest {
     }
 
     @Test
+    fun `confirming 1-min hold after delay removes latency from new timer`() = runTest(timeout = 10.seconds) {
+        val viewModel = createViewModel()
+        viewModel.sync1Min()
+
+        // Advance 10s
+        advanceTimeBy(10000)
+        runCurrent()
+
+        // Press Rolling Hold
+        viewModel.startRollingHold()
+
+        // Wait 50s until it prompts
+        advanceTimeBy(50000)
+        runCurrent()
+
+        assertEquals(TimerState.ROLLING_HOLD, viewModel.timerState.value)
+        assertEquals(0L, viewModel.remainingMillis.value)
+
+        // Wait 20 seconds before confirming
+        advanceTimeBy(20000)
+        runCurrent()
+
+        viewModel.onRollingHoldComplete(confirmed = true)
+
+        // 1 minute (60s) minus 20s latency = 40s remaining
+        assertEquals(TimerState.PREP_1_MIN, viewModel.timerState.value)
+        assertEquals(40000L, viewModel.remainingMillis.value)
+
+        viewModel.reset()
+    }
+
+    @Test
     fun `sync4Min sets remaining time to 4 minutes and state to WARNING_4_MIN`() = runTest(timeout = 10.seconds) {
         val viewModel = createViewModel()
         viewModel.sync4Min()

--- a/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
+++ b/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
@@ -53,8 +53,7 @@ class TimerViewModelTest {
         assertEquals(0L, viewModel.remainingMillis.value)
 
         // Wait 20 seconds before confirming
-        advanceTimeBy(20000)
-        runCurrent()
+        advanceTimeBy(20.seconds.inWholeMilliseconds)
 
         viewModel.onRollingHoldComplete(confirmed = true)
 

--- a/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
+++ b/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
@@ -41,8 +41,7 @@ class TimerViewModelTest {
         viewModel.sync1Min()
 
         // Advance 10s
-        advanceTimeBy(10000)
-        runCurrent()
+        advanceTimeBy(10.seconds.inWholeMilliseconds)
 
         // Press Rolling Hold
         viewModel.startRollingHold()

--- a/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
+++ b/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
@@ -59,7 +59,7 @@ class TimerViewModelTest {
 
         // 1 minute (60s) minus 20s latency = 40s remaining
         assertEquals(TimerState.PREP_1_MIN, viewModel.timerState.value)
-        assertEquals(40000L, viewModel.remainingMillis.value)
+        assertEquals(40.seconds.inWholeMilliseconds, viewModel.remainingMillis.value)
 
         viewModel.reset()
     }

--- a/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
+++ b/app/src/test/java/com/example/bumpscountdowntimer/ui/timer/TimerViewModelTest.kt
@@ -47,8 +47,7 @@ class TimerViewModelTest {
         viewModel.startRollingHold()
 
         // Wait 50s until it prompts
-        advanceTimeBy(50000)
-        runCurrent()
+        advanceTimeBy(50.seconds.inWholeMilliseconds)
 
         assertEquals(TimerState.ROLLING_HOLD, viewModel.timerState.value)
         assertEquals(0L, viewModel.remainingMillis.value)


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was a missing test for confirming a 1-minute hold after a race delay.
📊 **Coverage:** Added `confirming 1-min hold after delay removes latency from new timer` to `TimerViewModelTest.kt`.
✨ **Result:** Improved test coverage for the 1-minute synchronization path and latency-removal logic, ensuring the timer remains reliable during rolling holds.

---
*PR created automatically by Jules for task [1289827067772147802](https://jules.google.com/task/1289827067772147802) started by @triskaidekafeliks*