### PR TITLE
🔒 [security fix] Disable insecure Android backup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Changed `android:allowBackup` from `true` to `false` in `app/src/main/AndroidManifest.xml`.

⚠️ **Risk:** The potential impact if left unfixed
When `allowBackup` is set to `true`, application data can be extracted via `adb backup` or stored in unencrypted cloud backups, potentially exposing sensitive user data to unauthorized access.

🛡️ **Solution:** How the fix addresses the vulnerability
Disabling backups prevents the Android Backup Service from copying the application's data. Configuration for data extraction rules and full backup content is preserved to maintain existing security policies for device-to-device transfers.

---
*PR created automatically by Jules for task [18029332474296607908](https://jules.google.com/task/18029332474296607908) started by @triskaidekafeliks*